### PR TITLE
Merged vector decomp with main

### DIFF
--- a/LSCOintercurveschecker.py
+++ b/LSCOintercurveschecker.py
@@ -15,14 +15,12 @@ import conductivity
 def main():
 
     dispersionInstance = dispersion.LSCOdispersion()
-    initialpointsInstance = orbitcreation.InterpolatedCurves(200,dispersionInstance,True)
+    initialpointsInstance = orbitcreation.InterpolatedCurves(50,100,dispersionInstance,True)
 
     starttime = time()
     initialpointsInstance.solveforpoints(parallelised=False)
-    initialpointsInstance.extendedZoneMultiply(5)
-    initialpointsInstance.createPlaneAnchors(30)
-    #initialpointsInstance.plotpoints()
     endtime = time()
+    initialpointsInstance.plotpoints()
 
     print(f"Time taken to create initialcurves = {endtime - starttime}")
 
@@ -33,7 +31,7 @@ def main():
     #for curve in initialpointsInstance.extendedcurvesList:
     #    ax.scatter(curve[:,0],curve[:,1], curve[:,2], label='parametric curve',s=1)
 
-    theta = np.deg2rad(80)
+    theta = np.deg2rad(0)
     phi = np.deg2rad(0)
     B = [45*np.sin(theta)*np.cos(phi),45*np.sin(theta)*np.sin(phi),45*np.cos(theta)]
 
@@ -41,15 +39,9 @@ def main():
     #ax.scatter(intersections[:,0],intersections[:,1],intersections[:,2],c='#FF0000',s=10)
 
     starttime = time()
-    orbitsinstance = orbitcreation.NewOrbits(dispersionInstance,initialpointsInstance)
-    orbitsinstance.createOrbits(B,termination_resolution=0.1,mult_factor=10)
-    orbitsinstance.createOrbitsEQS(integration_resolution=0.1)
-    listoforbits = orbitsinstance.orbitsEQS
-    plt.show()    
-    #orbitsinstance.orbitdiagnosticplot()
-    listoforbits = orbitsinstance.orbitsEQS
+    orbitsinstance = orbitcreation.NewOrbits(dispersionInstance,initialpointsInstance,B)
     endtime = time()
-    print(f"Time taken to create orbits = {endtime - starttime}, number of orbits created {len(orbitsinstance.orbitsEQS)}, time spent finding intitialpoints {orbitsinstance.timespentfindingpoints}")
+    print(f"Time taken to create orbits = {endtime - starttime}, number of orbits created {len(orbitsinstance.orbitsEQS)}")
 
     starttime = time()
     conductivityInstance = conductivity.Conductivity(dispersionInstance,orbitsinstance,initialpointsInstance)
@@ -71,6 +63,7 @@ def main():
     conductivityInstance.createSigma()
     endtime = time()
     print(f"Time taken to calculate conductivity = {endtime - starttime}")
+    print(f"Calculated rho_zz: {np.linalg.inv(conductivityInstance.sigma)[2,2]*10e-5} mOhm cm")
 
     #orbitsinstance.orbitdiagnosticplot()
 

--- a/LSCOintercurveschecker.py
+++ b/LSCOintercurveschecker.py
@@ -15,21 +15,14 @@ import conductivity
 def main():
 
     dispersionInstance = dispersion.LSCOdispersion()
-    initialpointsInstance = orbitcreation.InterpolatedCurves(50,100,dispersionInstance,True)
+    FSorbitsInstance = orbitcreation.fermiSurfaceOrbits(20,200,dispersionInstance,True)
 
     starttime = time()
-    initialpointsInstance.solveforpoints(parallelised=False)
+    FSorbitsInstance.createFS(parallelised=False)
     endtime = time()
-    #initialpointsInstance.plotpoints()
+    FSorbitsInstance.plotpoints()
 
-    print(f"Time taken to create initialcurves = {endtime - starttime}")
-
-
-    #ax = plt.figure().add_subplot(projection='3d')
-
-    #plotting extendedcurveslist
-    #for curve in initialpointsInstance.extendedcurvesList:
-    #    ax.scatter(curve[:,0],curve[:,1], curve[:,2], label='parametric curve',s=1)
+    print(f"Time taken to create FSorbits = {endtime - starttime}, Number of orbits found = {len(FSorbitsInstance.FSorbits)}")
 
     theta = np.deg2rad(45)
     phi = np.deg2rad(0)
@@ -39,20 +32,19 @@ def main():
     #ax.scatter(intersections[:,0],intersections[:,1],intersections[:,2],c='#FF0000',s=10)
 
     starttime = time()
-    orbitsinstance = orbitcreation.NewOrbits(dispersionInstance,initialpointsInstance,B)
-    endtime = time()
-    print(f"Time taken to create orbits = {endtime - starttime}, number of orbits created {len(orbitsinstance.orbitsEQS)}")
-
-    starttime = time()
-    conductivityInstance = conductivity.Conductivity(dispersionInstance,orbitsinstance,initialpointsInstance)
+    conductivityInstance = conductivity.Conductivity(dispersionInstance,FSorbitsInstance)
     endtime = time()
     print(f"Time taken to create conductivityInstance =  {endtime - starttime}")
 
     starttime = time()
-    conductivityInstance.createAMatrix()
-    print(conductivityInstance.A.shape)
+    conductivityInstance.createAmatrix_Bindependent()
     endtime = time()
-    print(f"Time taken to create Amatrix =  {endtime - starttime}")
+    print(f"Time taken to create B independent Amatrix with shape {conductivityInstance.A_Bindependent.shape}=  {endtime - starttime}")
+
+    starttime = time()
+    conductivityInstance.createAmatrix_Bdependent(B)
+    endtime = time()
+    print(f"Time taken to create B dependent Amatrix =  {endtime - starttime}")
 
     starttime = time()
     conductivityInstance.createAlpha()
@@ -64,11 +56,6 @@ def main():
     endtime = time()
     print(f"Time taken to calculate conductivity = {endtime - starttime}")
     print(f"Calculated rho_zz: {np.linalg.inv(conductivityInstance.sigma)[2,2]*10e-5} mOhm cm")
-
-    #orbitsinstance.orbitdiagnosticplot()
-
-    #for orbit in listoforbits: ax.scatter(orbit[:,0],orbit[:,1],orbit[:,2],s=1)
-    #plt.show()    
 
 cProfile.run('main()',filename='stats.prof')
 #main()

--- a/LSCOintercurveschecker.py
+++ b/LSCOintercurveschecker.py
@@ -20,7 +20,7 @@ def main():
     starttime = time()
     initialpointsInstance.solveforpoints(parallelised=False)
     endtime = time()
-    initialpointsInstance.plotpoints()
+    #initialpointsInstance.plotpoints()
 
     print(f"Time taken to create initialcurves = {endtime - starttime}")
 
@@ -31,7 +31,7 @@ def main():
     #for curve in initialpointsInstance.extendedcurvesList:
     #    ax.scatter(curve[:,0],curve[:,1], curve[:,2], label='parametric curve',s=1)
 
-    theta = np.deg2rad(0)
+    theta = np.deg2rad(45)
     phi = np.deg2rad(0)
     B = [45*np.sin(theta)*np.cos(phi),45*np.sin(theta)*np.sin(phi),45*np.cos(theta)]
 

--- a/LSCOscalingtests_thetalist.py
+++ b/LSCOscalingtests_thetalist.py
@@ -7,8 +7,8 @@ from makesigmalist import makelist_parallel
 from time import time
 
 starttime_global = time()
-thetalist = np.linspace(0,360,100)
-phi = 0
+thetalist = np.linspace(0,180,80)
+phi = 45
 
 res_z = 20
 res_xy = 100
@@ -17,9 +17,10 @@ phi_rad = np.deg2rad(phi)
 dispersionInstance = dispersion.LSCOdispersion()
 FSorbitsInstance = orbitcreation.fermiSurfaceOrbits(res_z,res_xy,dispersionInstance,True)
 starttime = time()
-FSorbitsInstance.createFS(parallelised=False)
+FSorbitsInstance.createFS(tilingformat="variable",alpha=0.1,parallelised=False)
 endtime = time()
 print(f"Time taken to create Fermi Surface = {endtime - starttime}")
+FSorbitsInstance.plotpoints()
 
 conductivityInstance = conductivity.Conductivity(dispersionInstance,FSorbitsInstance)
 starttime = time()

--- a/LSCOscalingtests_thetalist.py
+++ b/LSCOscalingtests_thetalist.py
@@ -7,41 +7,36 @@ from makesigmalist import makelist_parallel
 from time import time
 
 starttime_global = time()
-thetalist = np.linspace(0,180,50)
+thetalist = np.linspace(0,360,100)
 phi = 0
 
 res_z = 20
-res_xy = 150
+res_xy = 100
 
 phi_rad = np.deg2rad(phi)
 dispersionInstance = dispersion.LSCOdispersion()
-initialpointsInstance = orbitcreation.InterpolatedCurves(res_z,res_xy,dispersionInstance,True)
-orbitsinstance = orbitcreation.NewOrbits(dispersionInstance,initialpointsInstance)
+FSorbitsInstance = orbitcreation.fermiSurfaceOrbits(res_z,res_xy,dispersionInstance,True)
 starttime = time()
-initialpointsInstance.solveforpoints(parallelised=False)
+FSorbitsInstance.createFS(parallelised=False)
 endtime = time()
-print(f"Time taken to create initialcurves = {endtime - starttime}")
+print(f"Time taken to create Fermi Surface = {endtime - starttime}")
 
+conductivityInstance = conductivity.Conductivity(dispersionInstance,FSorbitsInstance)
 starttime = time()
+conductivityInstance.createAmatrix_Bindependent()
+endtime = time()
+print(f"Time taken to create B independent Amatrix =  {endtime - starttime}")
+
 def getsigma(theta):
     B = [45*np.sin(np.deg2rad(theta))*np.cos(phi_rad),45*np.sin(np.deg2rad(theta))*np.sin(phi_rad),45*np.cos(np.deg2rad(theta))]
-    #print(f'orbitcreation completed for {theta} degrees')
-    #if theta>=60: orbitsinstance.plotOrbitsEQS() #enable plotting for diagnostic purposes
-    conductivityInstance = conductivity.Conductivity(dispersionInstance,orbitsinstance,initialpointsInstance,B)
-    conductivityInstance.createAMatrix()
+    conductivityInstance.createAmatrix_Bdependent(B)
     conductivityInstance.createAlpha()
     conductivityInstance.createSigma()
 
-    #orbitsinstance.orbitdiagnosticplot()
-    #print(f'matrixinversion performed for {theta}')
-    print(f"Theta={theta}. Calculated total area: {conductivityInstance.areasum}. Number of orbits used {len(conductivityInstance.orbitsInstance.orbitsEQS)}. Size of Amatrix: {conductivityInstance.n}")
+    print(f"Theta={theta}. Calculated total area: {conductivityInstance.areasum}. Number of orbits used {len(conductivityInstance.FSorbitsInstance.FSorbits)}. Size of Amatrix: {conductivityInstance.n}")
     return conductivityInstance.sigma,conductivityInstance.areasum
 
-
 sigmalist,rholist,arealist = makelist_parallel(getsigma,thetalist)
-endtime = time()
-print("Time taken to create orbits:",endtime-starttime)
-
 rhoxylist= [rho[2,2]*10e-5 for rho in rholist]
 
 endtime_global = time()

--- a/LSCOscalingtests_thetalist.py
+++ b/LSCOscalingtests_thetalist.py
@@ -7,12 +7,15 @@ from makesigmalist import makelist_parallel
 from time import time
 
 starttime_global = time()
-thetalist = np.linspace(0,90,25)
-phi = 30
+thetalist = np.linspace(0,180,50)
+phi = 0
+
+res_z = 20
+res_xy = 150
 
 phi_rad = np.deg2rad(phi)
 dispersionInstance = dispersion.LSCOdispersion()
-initialpointsInstance = orbitcreation.InterpolatedCurves(50,100,dispersionInstance,True)
+initialpointsInstance = orbitcreation.InterpolatedCurves(res_z,res_xy,dispersionInstance,True)
 orbitsinstance = orbitcreation.NewOrbits(dispersionInstance,initialpointsInstance)
 starttime = time()
 initialpointsInstance.solveforpoints(parallelised=False)
@@ -51,6 +54,6 @@ fig,axes = plt.subplots()
 axes.plot(thetalist,rhoxylist,ls="-",marker="o",ms=2)
 axes.set_ylabel(r"$\rho_{zz}$ ($m\Omega$ cm )")
 axes.set_xlabel(r'$\theta$')
-axes.text(70,5,r"Nd-LSCO x=0.24\nT=25 K\nB=45 T\n$\phi$=0")
+axes.text(0.1,0.1,f"Res={res_z}x{res_xy}\nPhi={phi} degrees",fontsize=10, transform=axes.transAxes)
 
 plt.show()

--- a/LSCOscalingtests_thetalist.py
+++ b/LSCOscalingtests_thetalist.py
@@ -7,29 +7,24 @@ from makesigmalist import makelist_parallel
 from time import time
 
 starttime_global = time()
-thetalist = np.linspace(0,45,50)
-phi = 0
+thetalist = np.linspace(0,90,25)
+phi = 30
 
 phi_rad = np.deg2rad(phi)
 dispersionInstance = dispersion.LSCOdispersion()
-initialpointsInstance = orbitcreation.InterpolatedCurves(200,dispersionInstance,True)
+initialpointsInstance = orbitcreation.InterpolatedCurves(50,100,dispersionInstance,True)
+orbitsinstance = orbitcreation.NewOrbits(dispersionInstance,initialpointsInstance)
 starttime = time()
 initialpointsInstance.solveforpoints(parallelised=False)
-initialpointsInstance.extendedZoneMultiply(5)
-initialpointsInstance.createPlaneAnchors(50)
 endtime = time()
 print(f"Time taken to create initialcurves = {endtime - starttime}")
 
 starttime = time()
 def getsigma(theta):
     B = [45*np.sin(np.deg2rad(theta))*np.cos(phi_rad),45*np.sin(np.deg2rad(theta))*np.sin(phi_rad),45*np.cos(np.deg2rad(theta))]
-    orbitsinstance = orbitcreation.NewOrbits(dispersionInstance,initialpointsInstance)
-    orbitsinstance.createOrbits(B,termination_resolution=0.05,mult_factor=15)
-    orbitsinstance.createOrbitsEQS(integration_resolution=0.05)
-    endtime = time()
     #print(f'orbitcreation completed for {theta} degrees')
     #if theta>=60: orbitsinstance.plotOrbitsEQS() #enable plotting for diagnostic purposes
-    conductivityInstance = conductivity.Conductivity(dispersionInstance,orbitsinstance,initialpointsInstance)
+    conductivityInstance = conductivity.Conductivity(dispersionInstance,orbitsinstance,initialpointsInstance,B)
     conductivityInstance.createAMatrix()
     conductivityInstance.createAlpha()
     conductivityInstance.createSigma()
@@ -49,14 +44,13 @@ rhoxylist= [rho[2,2]*10e-5 for rho in rholist]
 endtime_global = time()
 print(f"execution time: {endtime_global-starttime_global}")
 
-np.savetxt("rhoxyvst.dat",np.transpose([thetalist,rhoxylist]))
+np.savetxt("rhoxyvstPhi"+str(phi)+".dat",np.transpose([thetalist,rhoxylist]))
 
-plt.plot(thetalist,rhoxylist,ls="",marker="o",ms=2)
-plt.ylabel(r"$\rho_{zz}$ ($m\Omega$ cm )")
-plt.xlabel(r'$\theta$')
-plt.show()
+fig,axes = plt.subplots()
 
-plt.scatter(thetalist,arealist)
-plt.ylabel(r"$Area (\AA)$ cm )")
-plt.xlabel(r'$\theta$')
+axes.plot(thetalist,rhoxylist,ls="-",marker="o",ms=2)
+axes.set_ylabel(r"$\rho_{zz}$ ($m\Omega$ cm )")
+axes.set_xlabel(r'$\theta$')
+axes.text(70,5,r"Nd-LSCO x=0.24\nT=25 K\nB=45 T\n$\phi$=0")
+
 plt.show()

--- a/boltzmann_env.yml
+++ b/boltzmann_env.yml
@@ -2,7 +2,9 @@ name: boltzmann_env
 channels:
   - defaults
 dependencies:
-  - numbalsoda
+  - numpy
+  - matplotlib
+  - numba
   - scipy
   - joblib
   - sympy

--- a/conductivity.py
+++ b/conductivity.py
@@ -12,72 +12,83 @@ class Conductivity:
 
     Contains methods to calculate the Amatrix, alpha, and sigma
     """
-    def __init__(self,dispersionInstance,orbitsInstace,initialPointsInstance,B):
+    def __init__(self,dispersionInstance,FSorbitsInstance):
         self.dispersionInstance = dispersionInstance
-        self.orbitsInstance = orbitsInstace
-        self.initialPointsInstance = initialPointsInstance
-        self.B = B
+        self.FSorbitsInstance = FSorbitsInstance
 
-    def createAMatrix(self):
+    def createAmatrix_Bindependent(self):
+        """
+        Creates lists and functions used for the Amatrix calculations that are independent of the magnetic field
+        Then populates an Amatrix with terms independent of the magnetic field
+        """
         #n is the number of total points in our list, which is also the number of states in our Hilbert space,
         #and hence n x n is the size of our A matrix
-        self.n = self.initialPointsInstance.n_points*self.initialPointsInstance.n_cuts
+        self.n = self.FSorbitsInstance.n_points*self.FSorbitsInstance.n_cuts
 
         #create A matrix to populate with numbers:
-        self.A = np.zeros((self.n,self.n))
+        self.A_Bindependent = np.zeros((self.n,self.n))
 
         #Amatrixpositionlist[i,j] gives the row (or column) in self.A that corresponds to state self.orbitsInstance.orbitsEQS[i][j]
-        Amatrixpositionlist = np.arange(0, self.initialPointsInstance.n_points*self.initialPointsInstance.n_cuts).reshape(self.initialPointsInstance.n_points, self.initialPointsInstance.n_cuts)
+        self.Amatrixpositionlist = np.arange(0, self.FSorbitsInstance.n_points*self.FSorbitsInstance.n_cuts).reshape(self.FSorbitsInstance.n_points, self.FSorbitsInstance.n_cuts)
 
         #find state[i+1] - state[i-1] for states as you traverse an "in-plane" orbit, then compute their norms and unit vectors used to compute gradients
         deltaplist_inplane = []
-        for orbit in self.orbitsInstance.orbitsEQS:
+        for orbit in self.FSorbitsInstance.FSorbits:
             orbit_plus1 = np.roll(orbit,-1,axis=0)
             orbit_minus1 = np.roll(orbit,1,axis=0)
             deltaplist_inplane.append(orbit_plus1 - orbit_minus1)
         deltaparray_inplane =   np.array([value for sublist in deltaplist_inplane for value in sublist]) #this can be simplified, fix later
-        deltaparray_inplane_norms = np.linalg.norm(deltaparray_inplane,axis=1)
-        deltaparray_inplane_unitvectors = deltaparray_inplane/deltaparray_inplane_norms[:,None]
+        self.deltaparray_inplane_norms = np.linalg.norm(deltaparray_inplane,axis=1)
+        self.deltaparray_inplane_unitvectors = deltaparray_inplane/self.deltaparray_inplane_norms[:,None]
 
         #find state[i+1] - state[i-1] for states as you traverse an "out of plane" orbit, then compute their norms and unit vectors used to compute gradients
         deltaplist_outofplane = []
-        for id,orbit in enumerate(self.orbitsInstance.orbitsEQS):
-            orbit_plus1 = self.orbitsInstance.orbitsEQS[(id+1)%len(self.orbitsInstance.orbitsEQS)]
-            orbit_minus1 = self.orbitsInstance.orbitsEQS[(id-1)%len(self.orbitsInstance.orbitsEQS)]
-            BZlength = (2*np.pi)/self.initialPointsInstance.c
+        for id,orbit in enumerate(self.FSorbitsInstance.FSorbits):
+            orbit_plus1 = self.FSorbitsInstance.FSorbits[(id+1)%len(self.FSorbitsInstance.FSorbits)]
+            orbit_minus1 = self.FSorbitsInstance.FSorbits[(id-1)%len(self.FSorbitsInstance.FSorbits)]
+            BZlength = (2*np.pi)/self.FSorbitsInstance.c
             deltaplist_outofplane.append((orbit_plus1 - orbit_minus1 + BZlength/2)%(BZlength) - (BZlength/2))
         deltaparray_outofplane =   np.array([value for sublist in deltaplist_outofplane for value in sublist]) #this can be simplified, fix later
-        deltaparray_outofplane_norms = np.linalg.norm(deltaparray_outofplane,axis=1)
-        deltaparray_outofplane_unitvectors = deltaparray_outofplane/deltaparray_outofplane_norms[:,None]
-
-        #number that denotes the index of the beginning of the current submatrix
-        submatrixindex = 0
-        submatrixindexlist = [0] #keeps track of all submatrix starting points
+        self.deltaparray_outofplane_norms = np.linalg.norm(deltaparray_outofplane,axis=1)
+        self.deltaparray_outofplane_unitvectors = deltaparray_outofplane/self.deltaparray_outofplane_norms[:,None]
 
         #creates a list of states in the same order as they would appear in the double loop
-        stateslist = np.array([state for orbit in self.orbitsInstance.orbitsEQS for state in orbit]) #stateslist[i] = ith state
-        invtaulist = self.dispersionInstance.invtau(np.transpose(stateslist)) #invtaulist[i]  = invtau(stateslist[i])
+        stateslist = np.array([state for orbit in self.FSorbitsInstance.FSorbits for state in orbit]) #stateslist[i] = ith state
+        self.invtaulist = self.dispersionInstance.invtau(np.transpose(stateslist)) #invtaulist[i]  = invtau(stateslist[i])
         self.dedk_list = np.transpose(self.dispersionInstance.dedk(np.transpose(stateslist))) #self.dedk_list[i] = dedk(stateslist[i])
+
+        #now populate the Amatrix with B independent terms
+        i=0 #i and j correspond to the ith orbit and jth state on that orbit that is being iterated
+        for orbit in self.FSorbitsInstance.FSorbits:
+            j=0
+            for state in orbit:
+                #diagonal term coming from scattering out
+                Amatrixposition = self.Amatrixpositionlist[i,j]
+                self.A_Bindependent[Amatrixposition,Amatrixposition] += self.invtaulist[Amatrixposition]
+                j+= 1
+            i+= 1
+
+    def createAmatrix_Bdependent(self,B):
+        self.A = np.copy(self.A_Bindependent) #create a copy of the B independent Amatrix to populate with B dependent terms
+        self.B = B
         crosslist  = np.cross(self.dedk_list,self.B) #crosslist[i]  = dedk(state[i]) x B
-        dotlist_inplane = np.sum(crosslist*deltaparray_inplane_unitvectors,axis=1) #dotlist_inplane[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1])
-        dotlist_outofplane = np.sum(crosslist*deltaparray_outofplane_unitvectors,axis=1) #dotlist_outofplane[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1]) for out of plane states
-        graddatalist_inplane = dotlist_inplane/(deltaparray_inplane_norms*(6.582119569**2)) #graddatalist[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1])/norm(state[i+1] - state[i-1])
-        graddatalist_outofplane = dotlist_outofplane/(deltaparray_outofplane_norms*(6.582119569**2)) #graddatalist[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1])/norm(state[i+1] - state[i-1]) for out of plane states
+        dotlist_inplane = np.sum(crosslist*self.deltaparray_inplane_unitvectors,axis=1) #dotlist_inplane[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1])
+        dotlist_outofplane = np.sum(crosslist*self.deltaparray_outofplane_unitvectors,axis=1) #dotlist_outofplane[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1]) for out of plane states
+        graddatalist_inplane = dotlist_inplane/(self.deltaparray_inplane_norms*(6.582119569**2)) #graddatalist[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1])/norm(state[i+1] - state[i-1])
+        graddatalist_outofplane = dotlist_outofplane/(self.deltaparray_outofplane_norms*(6.582119569**2)) #graddatalist[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1])/norm(state[i+1] - state[i-1]) for out of plane states
 
         i=0 #i and j correspond to the ith orbit and jth state on that orbit that is being iterated
-        n = len(self.orbitsInstance.orbitsEQS) #n is the number of orbits
-        for orbit in self.orbitsInstance.orbitsEQS:
+        n = len(self.FSorbitsInstance.FSorbits) #n is the number of orbits
+        for orbit in self.FSorbitsInstance.FSorbits:
             m = len(orbit) #m is the number of states on the current orbit
             j=0
 
-            for state_id,state in enumerate(orbit):
-                #diagonal term coming from scattering out
-                Amatrixposition = Amatrixpositionlist[i,j]
-                self.A[Amatrixposition,Amatrixposition] += invtaulist[Amatrixposition]
+            for state in orbit:
+                Amatrixposition = self.Amatrixpositionlist[i,j]
 
                 #off diagonal terms that simulate the derivative term from the boltzmann equation, in plane
-                next_Amatrixposition_inplane = Amatrixpositionlist[i,(j+1)%m]
-                prev_Amatrixposition_inplane = Amatrixpositionlist[i,(j-1)%m]
+                next_Amatrixposition_inplane = self.Amatrixpositionlist[i,(j+1)%m]
+                prev_Amatrixposition_inplane = self.Amatrixpositionlist[i,(j-1)%m]
  
                 graddata_inplane = graddatalist_inplane[Amatrixposition]
 
@@ -85,8 +96,8 @@ class Conductivity:
                 self.A[Amatrixposition,prev_Amatrixposition_inplane] += -graddata_inplane
 
                 #off diagonal terms that simulate the derivative term from the boltzmann equation, out of plane
-                next_Amatrixposition_outofplane = Amatrixpositionlist[(i+1)%n,j]
-                prev_Amatrixposition_outofplane = Amatrixpositionlist[(i-1)%n,j]
+                next_Amatrixposition_outofplane = self.Amatrixpositionlist[(i+1)%n,j]
+                prev_Amatrixposition_outofplane = self.Amatrixpositionlist[(i-1)%n,j]
 
                 graddata_outofplane = graddatalist_outofplane[Amatrixposition]
 
@@ -100,14 +111,12 @@ class Conductivity:
         #now add in scattering in terms coming from forward scattering
 
         #first create matrix whose {i,j} element is {k_i,k_j}, which will be an input to the scattering-in formula
-        plist = np.concatenate(self.orbitsInstance.orbitsEQS) #list of all momentum vectors in correct order
+        plist = np.concatenate(self.FSorbitsInstance.FSorbits) #list of all momentum vectors in correct order
 
         indices = np.indices([self.n,self.n]) #list of indices {i,j} to be extracted from plist  
 
         pi_minus_pj = (plist[indices])[0] - (plist[indices])[1] #the i,jth element of this matrix is p_i - p_j (directly features into the scattering in matrix)
          
-
-
 
     def createAlpha(self):
         #creates an array of the cartesian components of the velocity at each point on the discretized fermi surface
@@ -123,11 +132,11 @@ class Conductivity:
         self.sigma = np.zeros([3,3])
 
         #perptermlist[i] is a vector that lies along the fermi surface, pointing from the ith point to the orbit above it
-        perptermlist = self.dispersionInstance.dkperp(self.initialPointsInstance.dkz,self.initialPointsInstance.dkz,self.dedk_list)
+        perptermlist = self.dispersionInstance.dkperp(self.FSorbitsInstance.dkz,self.FSorbitsInstance.dkz,self.dedk_list)
 
         #nextstatepointerarray[i] is a vector that lies along the fermi surface and points from the ith point to the succeeding point on a given orbit
         nextstatepointerlist = []
-        for orbit in self.orbitsInstance.orbitsEQS:
+        for orbit in self.FSorbitsInstance.FSorbits:
             orbit_plus1 = np.roll(orbit,-1,axis=0)
             nextstatepointerlist.append(orbit - orbit_plus1)
         nextstatepointerarray =   np.array([value for sublist in nextstatepointerlist for value in sublist])

--- a/conductivity.py
+++ b/conductivity.py
@@ -20,21 +20,34 @@ class Conductivity:
     def createAMatrix(self):
         #n is the number of total points in our list, which is also the number of states in our Hilbert space,
         #and hence n x n is the size of our A matrix
-        self.n = 0
-        for orbit in self.orbitsInstance.orbitsEQS:
-            self.n  += len(orbit)
+        self.n = self.initialPointsInstance.n_points*self.initialPointsInstance.n_cuts
 
-        deltaplist = []
+        #create A matrix to populate with numbers:
+        self.A = np.zeros((self.n,self.n))
+
+        #Amatrixpositionlist[i,j] gives the row (or column) in self.A that corresponds to state self.orbitsInstance.orbitsEQS[i][j]
+        Amatrixpositionlist = np.arange(0, self.initialPointsInstance.n_points*self.initialPointsInstance.n_cuts).reshape(self.initialPointsInstance.n_points, self.initialPointsInstance.n_cuts)
+
+        #find state[i+1] - state[i-1] for states as you traverse an "in-plane" orbit, then compute their norms and unit vectors used to compute gradients
+        deltaplist_inplane = []
         for orbit in self.orbitsInstance.orbitsEQS:
             orbit_plus1 = np.roll(orbit,-1,axis=0)
             orbit_minus1 = np.roll(orbit,1,axis=0)
-            deltaplist.append(np.linalg.norm(orbit_plus1 - orbit_minus1,axis=1))
-        deltaparray =   np.array([value for sublist in deltaplist for value in sublist])
+            deltaplist_inplane.append(orbit_plus1 - orbit_minus1)
+        deltaparray_inplane =   np.array([value for sublist in deltaplist_inplane for value in sublist]) #this can be simplified, fix later
+        deltaparray_inplane_norms = np.linalg.norm(deltaparray_inplane,axis=1)
+        deltaparray_inplane_unitvectors = deltaparray_inplane/deltaparray_inplane_norms[:,None]
 
-        #units of A are ps-1
-        Adata = []
-        Aposition_i = []
-        Aposition_j = []
+        #find state[i+1] - state[i-1] for states as you traverse an "out of plane" orbit, then compute their norms and unit vectors used to compute gradients
+        deltaplist_outofplane = []
+        for id,orbit in enumerate(self.orbitsInstance.orbitsEQS):
+            orbit_plus1 = self.orbitsInstance.orbitsEQS[(id+1)%len(self.orbitsInstance.orbitsEQS)]
+            orbit_minus1 = self.orbitsInstance.orbitsEQS[(id-1)%len(self.orbitsInstance.orbitsEQS)]
+            BZlength = (2*np.pi)/self.initialPointsInstance.c
+            deltaplist_outofplane.append((orbit_plus1 - orbit_minus1 + BZlength/2)%(BZlength) - (BZlength/2))
+        deltaparray_outofplane =   np.array([value for sublist in deltaplist_outofplane for value in sublist]) #this can be simplified, fix later
+        deltaparray_outofplane_norms = np.linalg.norm(deltaparray_outofplane,axis=1)
+        deltaparray_outofplane_unitvectors = deltaparray_outofplane/deltaparray_outofplane_norms[:,None]
 
         #number that denotes the index of the beginning of the current submatrix
         submatrixindex = 0
@@ -45,29 +58,28 @@ class Conductivity:
         invtaulist = self.dispersionInstance.invtau(np.transpose(stateslist)) #invtaulist[i]  = invtau(stateslist[i])
         self.dedk_list = np.transpose(self.dispersionInstance.dedk(np.transpose(stateslist))) #self.dedk_list[i] = dedk(stateslist[i])
         crosslist  = np.cross(self.dedk_list,self.orbitsInstance.B) #crosslist[i]  = dedk(state[i]) x B
-        normlist = np.linalg.norm(crosslist,axis=1) #normlist[i] = norm(dedk(state[i]) x B)
-        graddatalist = normlist/(deltaparray*(6.582119569**2)) #graddatalist[i] = norm(dedk(state[i]) x B)/norm(state[i+1] - state[i])
+        dotlist_inplane = np.sum(crosslist*deltaparray_inplane_unitvectors,axis=1) #dotlist_inplane[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1])
+        dotlist_outofplane = np.sum(crosslist*deltaparray_outofplane_unitvectors,axis=1) #dotlist_outofplane[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1]) for out of plane states
+        graddatalist_inplane = dotlist_inplane/(deltaparray_inplane_norms*(6.582119569**2)) #graddatalist[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1])/norm(state[i+1] - state[i-1])
+        graddatalist_outofplane = dotlist_outofplane/(deltaparray_outofplane_norms*(6.582119569**2)) #graddatalist[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1])/norm(state[i+1] - state[i-1]) for out of plane states
 
-        #i is an iterator that iterates over the hilbert space
-        i=0
-
-        #create A matrix to populate with numbers:
-        self.A = np.zeros((self.n,self.n))
-
+        i=0 #i and j correspond to the ith orbit and jth state on that orbit that is being iterated
         for orbit in self.orbitsInstance.orbitsEQS:
             m = len(orbit) #m x m is the size of the submatrix for this orbit
+            j=0
 
             for state_id,state in enumerate(orbit):
                 #diagonal term coming from scattering out
-                self.A[i,i] = invtaulist[i]
+                Amatrixposition = Amatrixpositionlist[i,j]
+                self.A[Amatrixposition,Amatrixposition] = invtaulist[Amatrixposition]
 
                 #off diagonal terms that simulate the derivative term from the boltzmann equation
-                i_next = ((i + 1) - submatrixindex)%m + submatrixindex
-                i_prev = ((i - 1) - submatrixindex)%m + submatrixindex
+                next_Amatrixposition_inplane = Amatrixpositionlist[i,(j+1)%m]
+                prev_Amatrixposition_inplane = Amatrixpositionlist[i,(j-1)%m]
  
-                graddata = graddatalist[i]
+                graddata = graddatalist_inplane[Amatrixposition]
 
-                self.A[i,i_next] = graddata
+                self.A[Amatrixposition,next_Amatrixposition_inplane] = graddata
 
                 #TEST BY CHANGING DIFFERENTIATION METHOD:
                 #self.A[i,i_next] += np.linalg.norm(np.cross(self.dispersionInstance.dedk(state),self.orbitsInstance.B))/(dispersion.deltap(orbit[i_next-submatrixindex],orbit[i - submatrixindex])*43.32)
@@ -76,15 +88,13 @@ class Conductivity:
                 #print(deltap(orbit1[i_next-submatrixindex],orbit1[i_prev - submatrixindex]))
                 #print(state)
 
-                self.A[i,i_prev] = -graddata
+                self.A[Amatrixposition,prev_Amatrixposition_inplane] = -graddata
 
                 #TEST BY CHANGING DIFFERENTIATION METHOD:
                 #self.A[i,i] += -self.A[i,i_next]
+                j += 1
+            i += 1
 
-                i += 1
-
-            submatrixindex += len(orbit)
-            submatrixindexlist.append(submatrixindex)
 
         #now add in scattering in terms coming from forward scattering
 

--- a/conductivity.py
+++ b/conductivity.py
@@ -12,10 +12,11 @@ class Conductivity:
 
     Contains methods to calculate the Amatrix, alpha, and sigma
     """
-    def __init__(self,dispersionInstance,orbitsInstace,initialPointsInstance):
+    def __init__(self,dispersionInstance,orbitsInstace,initialPointsInstance,B):
         self.dispersionInstance = dispersionInstance
         self.orbitsInstance = orbitsInstace
         self.initialPointsInstance = initialPointsInstance
+        self.B = B
 
     def createAMatrix(self):
         #n is the number of total points in our list, which is also the number of states in our Hilbert space,
@@ -57,41 +58,41 @@ class Conductivity:
         stateslist = np.array([state for orbit in self.orbitsInstance.orbitsEQS for state in orbit]) #stateslist[i] = ith state
         invtaulist = self.dispersionInstance.invtau(np.transpose(stateslist)) #invtaulist[i]  = invtau(stateslist[i])
         self.dedk_list = np.transpose(self.dispersionInstance.dedk(np.transpose(stateslist))) #self.dedk_list[i] = dedk(stateslist[i])
-        crosslist  = np.cross(self.dedk_list,self.orbitsInstance.B) #crosslist[i]  = dedk(state[i]) x B
+        crosslist  = np.cross(self.dedk_list,self.B) #crosslist[i]  = dedk(state[i]) x B
         dotlist_inplane = np.sum(crosslist*deltaparray_inplane_unitvectors,axis=1) #dotlist_inplane[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1])
         dotlist_outofplane = np.sum(crosslist*deltaparray_outofplane_unitvectors,axis=1) #dotlist_outofplane[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1]) for out of plane states
         graddatalist_inplane = dotlist_inplane/(deltaparray_inplane_norms*(6.582119569**2)) #graddatalist[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1])/norm(state[i+1] - state[i-1])
         graddatalist_outofplane = dotlist_outofplane/(deltaparray_outofplane_norms*(6.582119569**2)) #graddatalist[i] = (dedk(state[i]) x B) . unitvec(state[i+1] - state[i-1])/norm(state[i+1] - state[i-1]) for out of plane states
 
         i=0 #i and j correspond to the ith orbit and jth state on that orbit that is being iterated
+        n = len(self.orbitsInstance.orbitsEQS) #n is the number of orbits
         for orbit in self.orbitsInstance.orbitsEQS:
-            m = len(orbit) #m x m is the size of the submatrix for this orbit
+            m = len(orbit) #m is the number of states on the current orbit
             j=0
 
             for state_id,state in enumerate(orbit):
                 #diagonal term coming from scattering out
                 Amatrixposition = Amatrixpositionlist[i,j]
-                self.A[Amatrixposition,Amatrixposition] = invtaulist[Amatrixposition]
+                self.A[Amatrixposition,Amatrixposition] += invtaulist[Amatrixposition]
 
-                #off diagonal terms that simulate the derivative term from the boltzmann equation
+                #off diagonal terms that simulate the derivative term from the boltzmann equation, in plane
                 next_Amatrixposition_inplane = Amatrixpositionlist[i,(j+1)%m]
                 prev_Amatrixposition_inplane = Amatrixpositionlist[i,(j-1)%m]
  
-                graddata = graddatalist_inplane[Amatrixposition]
+                graddata_inplane = graddatalist_inplane[Amatrixposition]
 
-                self.A[Amatrixposition,next_Amatrixposition_inplane] = graddata
+                self.A[Amatrixposition,next_Amatrixposition_inplane] += graddata_inplane
+                self.A[Amatrixposition,prev_Amatrixposition_inplane] += -graddata_inplane
 
-                #TEST BY CHANGING DIFFERENTIATION METHOD:
-                #self.A[i,i_next] += np.linalg.norm(np.cross(self.dispersionInstance.dedk(state),self.orbitsInstance.B))/(dispersion.deltap(orbit[i_next-submatrixindex],orbit[i - submatrixindex])*43.32)
+                #off diagonal terms that simulate the derivative term from the boltzmann equation, out of plane
+                next_Amatrixposition_outofplane = Amatrixpositionlist[(i+1)%n,j]
+                prev_Amatrixposition_outofplane = Amatrixpositionlist[(i-1)%n,j]
 
-                #testing print
-                #print(deltap(orbit1[i_next-submatrixindex],orbit1[i_prev - submatrixindex]))
-                #print(state)
+                graddata_outofplane = graddatalist_outofplane[Amatrixposition]
 
-                self.A[Amatrixposition,prev_Amatrixposition_inplane] = -graddata
+                self.A[Amatrixposition,next_Amatrixposition_outofplane] += graddata_outofplane
+                self.A[Amatrixposition,prev_Amatrixposition_outofplane] += -graddata_outofplane
 
-                #TEST BY CHANGING DIFFERENTIATION METHOD:
-                #self.A[i,i] += -self.A[i,i_next]
                 j += 1
             i += 1
 
@@ -122,7 +123,7 @@ class Conductivity:
         self.sigma = np.zeros([3,3])
 
         #perptermlist[i] is a vector that lies along the fermi surface, pointing from the ith point to the orbit above it
-        perptermlist = self.dispersionInstance.dkperp(self.orbitsInstance.B,self.initialPointsInstance.dkz,self.dedk_list)
+        perptermlist = self.dispersionInstance.dkperp(self.initialPointsInstance.dkz,self.initialPointsInstance.dkz,self.dedk_list)
 
         #nextstatepointerarray[i] is a vector that lies along the fermi surface and points from the ith point to the succeeding point on a given orbit
         nextstatepointerlist = []

--- a/conductivity.py
+++ b/conductivity.py
@@ -89,7 +89,7 @@ class Conductivity:
                 #off diagonal terms that simulate the derivative term from the boltzmann equation, in plane
                 next_Amatrixposition_inplane = self.Amatrixpositionlist[i,(j+1)%m]
                 prev_Amatrixposition_inplane = self.Amatrixpositionlist[i,(j-1)%m]
- 
+
                 graddata_inplane = graddatalist_inplane[Amatrixposition]
 
                 self.A[Amatrixposition,next_Amatrixposition_inplane] += graddata_inplane
@@ -113,10 +113,10 @@ class Conductivity:
         #first create matrix whose {i,j} element is {k_i,k_j}, which will be an input to the scattering-in formula
         plist = np.concatenate(self.FSorbitsInstance.FSorbits) #list of all momentum vectors in correct order
 
-        indices = np.indices([self.n,self.n]) #list of indices {i,j} to be extracted from plist  
+        indices = np.indices([self.n,self.n]) #list of indices {i,j} to be extracted from plist
 
         pi_minus_pj = (plist[indices])[0] - (plist[indices])[1] #the i,jth element of this matrix is p_i - p_j (directly features into the scattering in matrix)
-         
+
 
     def createAlpha(self):
         #creates an array of the cartesian components of the velocity at each point on the discretized fermi surface

--- a/dispersion.py
+++ b/dispersion.py
@@ -3,29 +3,6 @@ import numpy as np
 from math import sqrt
 from numba import njit
 
-def deltap(p1,p2):
-    #takes input p1 and p2 as lists and returns magnitude of their difference
-    #works only for p1 and p2 of length 3
-    return norm([p1[i]-p2[i] for i in range(3)])
-
-def cross(a, b):
-    #manually defined cross product since np.cross is very slow
-    result = [a[1]*b[2] - a[2]*b[1],
-            a[2]*b[0] - a[0]*b[2],
-            a[0]*b[1] - a[1]*b[0]]
-
-    return result
-
-def dot(a,b):
-    #manually defined dot product since numpy is very slow
-    result = a[0]*b[0] + a[1]*b[1] + a[2]*b[2]
-    return result
-
-def norm(p):
-    #manually define norm without going through numpy
-    result = sqrt(p[0]**2 + p[1]**2 + p[2]**2)
-    return result
-
 class LSCOdispersion:
     """
     Inputs:
@@ -49,8 +26,7 @@ class LSCOdispersion:
         self.b= self.a
         self.c = 2*6.6
 
-        #hopping parameters in eV from Yawen and Gael's paper:
-        T = (160)*(10**(-3))
+        #multiply parameters by T to get unitfull parameters in eV:
         T1 = T1multvalue*T
         T11 = T11multvalue*T
         Tz = Tzmultvalue*T
@@ -120,24 +96,22 @@ class FREEdispersion:
     """
     Inputs:
     mumultvalue (multiplicative factor that sets doping and hence chemical potential)
-    mumultvalue = 0.8243(critical point) or 1.15(far from lifshits singularity)
 
-    Class represents LSCO dispersion (remember to set doublefermisurface = True!)
+    Class represents a cylindrical free electron dispersion in the plane with some z axis warping
     Contains symbolic calculations that are lambdified to generate numeric values of important dispersion parameters
     """
-    def __init__(self,mumultvalue=0.8243):
+    def __init__(self,mu=7):
 
         #############################################################################################
-        #LSCO specific functions are below
+        #FREE electron specific functions are below
         #############################################################################################
 
         #define lattice constants in angstroms
         self.a = 1
         self.b= self.a
         self.c = 2
-
-        #hopping parameters in eV from Yawen and Gael's paper:
-        self.mu=7
+        self.mu=mu
+        
         #now we symbolically define the dispersion
         kx, ky, kz = symp.symbols('kx ky kz')
 

--- a/orbitcreation.py
+++ b/orbitcreation.py
@@ -38,8 +38,10 @@ class InterpolatedCurves:
     This class replaces the older InitialPoints class, and is compatible with the Conductivity class out of the box
     """
 
-    def __init__(self,npoints,dispersion,doublefermisurface):
+    def __init__(self,n_points,n_cuts,dispersion,doublefermisurface):
         self.dispersion = dispersion
+        self.n_cuts = n_cuts
+        self.n_points = n_points
 
         if not isinstance(doublefermisurface,bool): #check if doublefermisurface is correctly specified
             raise Exception("Argument doublefermisurface is not a boolean")
@@ -47,15 +49,16 @@ class InterpolatedCurves:
         self.doublefermisurface = doublefermisurface
         self.c = self.dispersion.c/(1+int(self.doublefermisurface)) #this makes c = dispersion.c/2 if doublefermisurface is True
 
-        self.planeZcoords = np.linspace(-(np.pi)/self.c,(np.pi)/self.c,npoints+1) #create zcoordinates, each defining a plane on which points used for interpolation will be found. Exclude endpoint so that zone can be multiplied easily
+        self.planeZcoords = np.linspace(-(np.pi)/self.c,(np.pi)/self.c,n_points+1) #create zcoordinates, each defining a plane on which points used for interpolation will be found. Exclude endpoint so that zone can be multiplied easily
+        self.dkz = np.array([0,0,self.planeZcoords[1] - self.planeZcoords[0]]) #vector connecting two planes used for area calculations in conductivity
 
-        self.initialcurvesList = [] #list of list of initialpoints. each sublist should be a contiguous set of points. eg: [[point1-,point2-,point3-],[point1+,point2+,point3+]]
-        self.interpolatedcurveslist = [] #list of interpolated functions that output [x,y] coordinates along a set of points when given a z-coordinate
+        self.initialcurvesList = np.zeros((n_points,n_cuts,3)) #list of list of initialpoints lying on the fermi surface. each sublist should be a contiguous set of points. eg: [[point1-,point2-,point3-],[point1+,point2+,point3+]]
 
     def solveforpoints(self,parallelised=False):
         """
         Solves for points on four sides of the fermi surface
         Inputs:
+        n_cuts (number of cuts along which to solve for points. each cut is a line along which points lying on the fermi surface are solved for)
         parallelised (bool, True if solving for points is to be parallelised across cores)
         Creates:
         initialcurvesList (a list containing two numpy arrays, with each numpy array containing contiguous points lying along the fermi surface)
@@ -63,7 +66,7 @@ class InterpolatedCurves:
 
         #angularwidth = np.pi/10 #angular width around van hole points to solve for points
         #philist = np.concatenate([np.linspace(-angularwidth+alpha,angularwidth+alpha,6) for alpha in np.linspace(0,2*np.pi,4,endpoint=False)]) #list of phis along which to find curves lying on the fermi surface
-        philist = [0,np.pi]
+        philist = np.arange(0,2*np.pi,2*np.pi/self.n_cuts) #list of phis along which to find curves lying on the fermi surface
 
         def getpoints(startingZcoords,phi):
             """
@@ -81,12 +84,10 @@ class InterpolatedCurves:
             return np.transpose(np.array([r0*np.cos(phi),r0*np.sin(phi),startingZcoords]))
 
         #create startingpoints by iterating getpoints() over self.planeZcoords
-        for phi in philist:
+        for id,phi in enumerate(philist):
             startingpointsarray = getpoints(self.planeZcoords,phi)
 
-            self.initialcurvesList.append(np.delete(startingpointsarray,-1,axis=0))
-
-            self.interpolatedcurveslist.append(interp1d(np.transpose(startingpointsarray[:,2]),np.transpose(startingpointsarray[:,0:2])))
+            self.initialcurvesList[:,id] = np.delete(startingpointsarray,-1,axis=0)
 
     def plotpoints(self):
         ax = plt.figure().add_subplot(projection='3d')
@@ -96,94 +97,12 @@ class InterpolatedCurves:
             ax.scatter(curve[:,0],curve[:,1], curve[:,2], label='parametric curve',s=10)
 
         #plotting interpolatedcurves
-        interpolatedcurveslist = np.array([[[interpolatingfunction(kz)[0],interpolatingfunction(kz)[1],kz] for kz in np.linspace((-np.pi)/self.c,(np.pi)/self.c,1000)] for interpolatingfunction in self.interpolatedcurveslist])
+        #interpolatedcurveslist = np.array([[[interpolatingfunction(kz)[0],interpolatingfunction(kz)[1],kz] for kz in np.linspace((-np.pi)/self.c,(np.pi)/self.c,1000)] for interpolatingfunction in self.interpolatedcurveslist])
 
-        for curve in interpolatedcurveslist:
-            ax.scatter(curve[:,0],curve[:,1], curve[:,2], label='parametric curve',s=1)
+        #for curve in interpolatedcurveslist:
+        #    ax.scatter(curve[:,0],curve[:,1], curve[:,2], label='parametric curve',s=1)
 
         plt.show()
-
-    def extendedZoneMultiply(self,nzones=1):
-        """
-        Extends initialcurvesList to 2*nzones zones lying along the kz direction. nzones in positive kz, nzones in negative kz.
-        Creates:
-        extendedcurvesList (a list containing two numpy arrays, with each numpy array containing contiguous points lying along the fermi surface)
-        """
-        self.extendedcurvesList = []
-
-        c = self.dispersion.c/(1+int(self.doublefermisurface)) #this makes c = dispersion.c/2 if doublefermisurface is True
-
-        if not hasattr(self,'initialcurvesList'): raise Exception("initialcurvesList has not been created. Call solveforpoints() first.")
-
-        for curve in self.initialcurvesList:
-
-            extendedcurve = curve
-
-            for zonenumber in range(1,nzones+1): #iterates from 1 to nzones
-                previouszoneCurve = curve + [0,0,-(2*np.pi*zonenumber)/c] #create initial curve in the BZ below extendedcurve
-                nextzoneCurve = curve + [0,0,+(2*np.pi*zonenumber)/c]   #create initial curve in the BZ above extendedcurve
-                extendedcurve = np.concatenate((previouszoneCurve,extendedcurve,nextzoneCurve),axis=0) #concatenate all three curves to extend extendedcurve by one BZ on each side
-
-            self.extendedcurvesList.append(extendedcurve)
-
-
-    def findintersections(self,normalvector,pointonplane):
-        """
-        Find intersections between self.extendedcurveslist and the plane defined by normalvector and pointonplane
-        Returns an array of intersection points
-        """
-        def planeequation(kvector):
-            """
-            planeequation(kvector) = 0 is the equation of the plane defined by normalvector and pointonplane
-            """
-            return np.dot(kvector,normalvector) - np.dot(pointonplane,normalvector)
-
-        def binaryfindintersection(upperbound,lowerbound,planeequation,interpolatedcurve):
-            """
-            Inputs:
-            upperbound (3-vector denoting one end of curve in which planeequation=0 has to be found)
-            lowerbound (3-vector denoting the other end of curve in which planeequation=0 has to be found)
-            planeequation (function of [x,y,z] whose roots have to be found)
-            extendedinterpolatedcurve (function [x(z),y(z)] that parameterizes a curve between upperbound and lowerbound, along which a root will be found)
-            """
-            def extendedinterpolatedcurve(kz):
-                return interpolatedcurve(((kz+np.pi/self.c)%(2*np.pi/self.c) - np.pi/self.c))
-
-            upperz = upperbound[2]
-            lowerz = lowerbound[2]
-
-            zcoords = np.linspace(lowerz,upperz,1000) #array of z coordinates between upperz and lowerz to be used for finding a solution
-
-            interpolatedpoints = np.transpose(np.vstack((extendedinterpolatedcurve(zcoords),zcoords)))  #array of three vectors lying on the curve between upperz and lowerz, along whcih to find solutions
-            intersectionindices = [np.nonzero(np.diff(np.sign(planeequation(interpolatedpoints))))] #coordinate where planequation flips sign
-            
-            intersectionpoint = np.reshape(interpolatedpoints[intersectionindices],(3))
-
-            return intersectionpoint
-
-        intersectionindices = [np.nonzero(np.diff(np.sign(planeequation(curve)))) for curve in self.extendedcurvesList] #contains a list of indices for each set of points denoting intersections with the plane
-        intersectionpoints = []
-
-        for (curve_id,curve) in enumerate(self.extendedcurvesList):
-            for id in intersectionindices[curve_id][0]:
-                lowerbound = curve[id]
-                upperbound = curve[id+1]
-                intersectionpoints.append(binaryfindintersection(upperbound, lowerbound, planeequation, self.interpolatedcurveslist[curve_id]))
-
-        return np.array(intersectionpoints)
-
-    def createPlaneAnchors(self,n):
-        """
-        Inputs:
-        n (this denotes the number of plane anchors to create, each will lie along the z-axis. corresponds to the number of planes used to create orbits later)
-        """
-
-        c = self.dispersion.c/(1+int(self.doublefermisurface)) #this makes c = dispersion.c/2 if doublefermisurface is True
-
-        planeAnchors_zcoords = np.linspace(-(np.pi)/c,(np.pi)/c,n+1,endpoint=False) #create zcoordinates, each defining a plane on which orbits will be created
-        self.planeAnchors = [np.array([0,0,z]) for z in planeAnchors_zcoords] #make points out of zcoordinates, to be passed to createorbitsinplane()
-
-        self.dkz = self.planeAnchors[1] - self.planeAnchors[0] #this creates a vector that takes you from one plane to another
 
 
 class NewOrbits:
@@ -191,145 +110,12 @@ class NewOrbits:
     Inputs:
     dispersion (object of type dispersion)
     interpolatedcurves (onject of type interpolatedcurves)
-
+    B (magnetic field as a 3-vector)
     """
-    def __init__(self,dispersion,interpolatedcurves):
+    def __init__(self,dispersion,interpolatedcurves,B):
         self.dispersion = dispersion
         self.interpolatedcurves = interpolatedcurves
 
         self.timespentfindingpoints = 0
-
-        try:
-            self.interpolatedcurves.extendedcurvesList #since many methods for this class are defined using extendedcurvesList, this makes sure it exists
-        except NameError:
-            print("initialcurvesList not extended for interpolatedcurves, extending with nzones =1")
-            self.interpolatedcurves.extendedZoneMultiply()
-
-        #the force v \cross B term but now with fixed B
-        RHS_numeric = self.dispersion.RHS_numeric
-
-        @cfunc(lsoda_sig)
-        def RHS_withB(t,k,dk,B ):
-            [dk[0],dk[1],dk[2]] = RHS_numeric([k[0],k[1],k[2]],[B[0],B[1],B[2]])
-
-        self.RHS_withB_address = RHS_withB.address
-
-
-
-    def createOrbitsInPlane(self,B,pointonplane,termination_resolution,sampletimes,mult_factor,rtol,atol):
-        """
-        Inputs:
-        B (3-vector specifying direction of magnetic field)
-        pointonplane (a point lying in the plane of orbit to be created. Does not have to lie on the orbit itself.)
-        termination_resolution (radius in which integration terminates, default value 0.05)
-        sampletimes (times at which to sample solution)
-        mult_factor (multiplication factor for B during integration: larger means faster integration, but greater than 10 and integration breaks ihavenoideawhy)
-
-        Creates all possible orbits lying in the plane defined by B and pointonplane
-        """
-
-        #find starting points lying on plane and also time it
-        starttime = time()
-        initialpointslist = self.interpolatedcurves.findintersections(B,pointonplane)
-        endtime = time()
-        self.timespentfindingpoints += (endtime-starttime)
-
-        #list of orbits in plane
-        orbitsinplane = []
-
-        while initialpointslist.size > 0:
-            initial = np.array(initialpointslist[0])
-
-            #starttime = time()
-            solution,success = lsoda(self.RHS_withB_address, initial, sampletimes,data=B*mult_factor,rtol=rtol,atol=atol)
-            #endtime = time()
-            orbit = (solution)
-
-            #print("Time taken to create orbits = ",endtime - starttime)
-            
-            #now check if any other elements of initialpointslist appear in orbit
-
-            elementstobedeleted = []
-            for id,initialpoint in enumerate(initialpointslist):
-                normsarray = np.linalg.norm(orbit - initialpoint,axis=1)
-                closenessarray = np.isclose(normsarray,0,atol=termination_resolution)
-                if np.any(closenessarray):
-                    elementstobedeleted.append(id) 
-
-            initialpointslist = np.delete(initialpointslist,elementstobedeleted,axis=0)#deletes initial point elements that lie on the current orbit
-
-            orbitsinplane.append(orbit)
-
-        #print("Number of orbits created in plane:",len(orbitsinplane)) diagnostic to make sure all extra orbits are created
-        return orbitsinplane
-
-    def createOrbits(self,B,termination_resolution = 0.05,sampletimes = np.linspace(0,4,10000),mult_factor=1,rtol=1e-7,atol=1e-8):
-        """
-        Inputs:
-        B (3-vector specifying direction of magnetic field)
-        termination_resolution (radius in which integration terminates, default value 0.05)
-        sampletimes (times at which to sample solution) (default value is value for LSCO at critial doping)
-        mult_factor (multiplication factor for B during integration: larger means faster integration, but greater than 10 and integration breaks ihavenoideawhy)
-
-        Creates all possible orbits lying on planes defined by B and self.interpolatedcurves.planeAnchors
-        """
-        self.orbits = []
-        self.termination_resolution = termination_resolution
-        self.B = B
-        self.B_normalized = np.array(B)/dispersion.norm(B)
-
-        for point in self.interpolatedcurves.planeAnchors: #creates orbits for each planeanchor and then appends it to self.orbits
-            listoforbitsinplane = self.createOrbitsInPlane(self.B_normalized,point,termination_resolution = termination_resolution,sampletimes = sampletimes,mult_factor=mult_factor,rtol=rtol,atol=atol)
-            for orbit in listoforbitsinplane: self.orbits.append(orbit)
-
-    def createOrbitsEQS(self,integration_resolution=0.05):
-        """
-        Inputs:
-        integration_resolution (spacing between points, this becomes the resolution for integration when used in conjunction with a Conductivity object)
-
-        Creates:
-        List of equally spaced orbits orbitsEQS
-        """
-        self.orbitsEQS = []
-
-        def appendSingleOrbitEQS(orbit):
-            """
-            This function creates an equally spaced orbit out of the input orbit, and appends it to self.orbitsEQS if it has mroe than three points
-            """
-            #Find distances of points from initial point to tell where orbit closes
-            diffvectors = orbit - np.outer(np.ones(orbit.shape[0]),orbit[0])
-            diffvectorsnorm = np.linalg.norm(diffvectors,axis=1) #array of distances from initial point
-            d_diffvectorsnorm = np.diff(diffvectorsnorm,append=0) #derivative of diffvectorsnorm. Value of 0 appended to keep length same as diffvectorsnorm
-
-            #orbit is close to completion when 1.diffvectorsnorm is close to zero 2.the derivative of diffvectorssnorm is negative 
-            whereclosetozero = np.isclose(diffvectorsnorm,0,atol=integration_resolution)
-            wherenegativederivative = d_diffvectorsnorm < 0
-            orbitcompletionindices = np.arange(diffvectorsnorm.size)[np.logical_and(whereclosetozero,wherenegativederivative)] #set of indices where orbit closes
-
-            if orbitcompletionindices.size == 0:
-                raise Exception("Some orbits did not close! Increase integration time or mult_factor, and try again")
-
-            firstindexofcompletion = orbitcompletionindices[0] #first index where orbit closes
-            firstorbit = orbit[:firstindexofcompletion,:] #array elements corresponding to the first completed orbit
-
-            #plt.plot(firstorbit[:,0],ls ="",marker="o",ms = 1)
-            shiftedfirstorbit = np.roll(firstorbit,-1,axis=0)
-            cumnormslist = np.cumsum(np.linalg.norm(shiftedfirstorbit-firstorbit,axis=1))
-            equallyspacesindices = np.nonzero(np.diff(np.sign(np.sin(cumnormslist*np.pi/integration_resolution))))
-            singleorbitEQS = firstorbit[equallyspacesindices]
-
-            #if orbits1EQS has less than three points, we discard the orbit as numerical path derivatives won't be well defined
-            if not singleorbitEQS.shape[0] < 3:
-                self.orbitsEQS.append(singleorbitEQS)
-
-        for orbit in self.orbits: appendSingleOrbitEQS(orbit)
-
-    def orbitdiagnosticplot(self):
-        ax = plt.figure().add_subplot(projection='3d')
-
-        for curve in self.interpolatedcurves.extendedcurvesList:
-            ax.scatter(curve[:,0],curve[:,1], curve[:,2], label='parametric curve',s=1)
-
-        for orbit in self.orbitsEQS: ax.scatter(orbit[:,0],orbit[:,1],orbit[:,2],s=1)
-
-        plt.show()
+        self.orbitsEQS = self.interpolatedcurves.initialcurvesList
+        self.B = B #this definition is legacy since conductivity assumes NewOrbits.B exits, but needs to go and enter as an input to conductivity

--- a/orbitcreation.py
+++ b/orbitcreation.py
@@ -112,10 +112,9 @@ class NewOrbits:
     interpolatedcurves (onject of type interpolatedcurves)
     B (magnetic field as a 3-vector)
     """
-    def __init__(self,dispersion,interpolatedcurves,B):
+    def __init__(self,dispersion,interpolatedcurves):
         self.dispersion = dispersion
         self.interpolatedcurves = interpolatedcurves
 
         self.timespentfindingpoints = 0
         self.orbitsEQS = self.interpolatedcurves.initialcurvesList
-        self.B = B #this definition is legacy since conductivity assumes NewOrbits.B exits, but needs to go and enter as an input to conductivity

--- a/orbitcreation.py
+++ b/orbitcreation.py
@@ -52,16 +52,26 @@ class fermiSurfaceOrbits:
 
         self.initialcurvesList = np.zeros((self.n_points,self.n_cuts,3)) #list of list of initialpoints lying on the fermi surface. each sublist should be a contiguous set of points. eg: [[point1-,point2-,point3-],[point1+,point2+,point3+]]
 
-    def createFS(self,parallelised=False):
+    def createFS(self,tilingformat="variable",alpha=0,parallelised=False):
         """
         Solves for points on the fermi surface
         Inputs:
         parallelised (bool, True if solving for points is to be parallelised across cores)
+        tilingformat ("variable" if using an increased density of points near VHS, "regular" for uniform density of points)
+        alpha (larger alphas correspond to higher density of points near VHS)
         Creates:
         FSorbits (a numpy array with FSorbits[i] representing a single in-plane orbit)
         """
+        if tilingformat=="regular":
+            philist = np.arange(0,2*np.pi,2*np.pi/self.n_cuts) #list of phis along which to find curves lying on the fermi surface
+        else:
+            philist = np.arange(0,2*np.pi,2*np.pi/self.n_cuts)
+            philist = philist - alpha * np.sin(4*philist)
 
-        philist = np.arange(0,2*np.pi,2*np.pi/self.n_cuts) #list of phis along which to find curves lying on the fermi surface
+            isascending = np.all(np.diff(philist) > 0)
+            if not isascending:
+                raise Exception("alpha is too large and leads to overlapping points!")
+
 
         def getpoints(startingZcoords,phi):
             """

--- a/orbitcreation.py
+++ b/orbitcreation.py
@@ -25,16 +25,15 @@ if cpus >60: cpus =60 #joblib breaks if you use too many CPUS (>61)
 # Module to find number of CPUS
 ##########################
 
-class InterpolatedCurves:
+class fermiSurfaceOrbits:
     """
     Inputs:
-    npoints (number of points to solve for on each side of FS)
+    res_z (number of slices of the fermi surface in the z direction, with each slice lying in the xy plane)
+    res_xy (number of points to solve for in each slice)
     dispersion (object of class dispersion)
     doublefermisurface (bool, True if unit cell size is c/2)
-    B_parr (list containing two floats, representing the in plane direction of B)
-    B (if B_parr is not supplied, in plane direction of B will be inferred)
 
-    This class replaces the older InitialPoints class, and is compatible with the Conductivity class out of the box
+    Initializes an object to create orbits on the fermi surface
     """
 
     def __init__(self,res_z,res_xy,dispersion,doublefermisurface):
@@ -53,18 +52,15 @@ class InterpolatedCurves:
 
         self.initialcurvesList = np.zeros((self.n_points,self.n_cuts,3)) #list of list of initialpoints lying on the fermi surface. each sublist should be a contiguous set of points. eg: [[point1-,point2-,point3-],[point1+,point2+,point3+]]
 
-    def solveforpoints(self,parallelised=False):
+    def createFS(self,parallelised=False):
         """
-        Solves for points on four sides of the fermi surface
+        Solves for points on the fermi surface
         Inputs:
-        n_cuts (number of cuts along which to solve for points. each cut is a line along which points lying on the fermi surface are solved for)
         parallelised (bool, True if solving for points is to be parallelised across cores)
         Creates:
-        initialcurvesList (a list containing two numpy arrays, with each numpy array containing contiguous points lying along the fermi surface)
+        FSorbits (a numpy array with FSorbits[i] representing a single in-plane orbit)
         """
 
-        #angularwidth = np.pi/10 #angular width around van hole points to solve for points
-        #philist = np.concatenate([np.linspace(-angularwidth+alpha,angularwidth+alpha,6) for alpha in np.linspace(0,2*np.pi,4,endpoint=False)]) #list of phis along which to find curves lying on the fermi surface
         philist = np.arange(0,2*np.pi,2*np.pi/self.n_cuts) #list of phis along which to find curves lying on the fermi surface
 
         def getpoints(startingZcoords,phi):
@@ -85,35 +81,16 @@ class InterpolatedCurves:
         #create startingpoints by iterating getpoints() over self.planeZcoords
         for id,phi in enumerate(philist):
             startingpointsarray = getpoints(self.planeZcoords,phi)
-
             self.initialcurvesList[:,id] = np.delete(startingpointsarray,-1,axis=0)
+
+        self.FSorbits = self.initialcurvesList
 
     def plotpoints(self):
         ax = plt.figure().add_subplot(projection='3d')
 
         #plotting extendedcurveslist
         for curve in self.initialcurvesList:
-            ax.scatter(curve[:,0],curve[:,1], curve[:,2], label='parametric curve',s=10)
-
-        #plotting interpolatedcurves
-        #interpolatedcurveslist = np.array([[[interpolatingfunction(kz)[0],interpolatingfunction(kz)[1],kz] for kz in np.linspace((-np.pi)/self.c,(np.pi)/self.c,1000)] for interpolatingfunction in self.interpolatedcurveslist])
-
-        #for curve in interpolatedcurveslist:
-        #    ax.scatter(curve[:,0],curve[:,1], curve[:,2], label='parametric curve',s=1)
+            ax.scatter(curve[:,0],curve[:,1], curve[:,2], label='parametric curve',s=5)
 
         plt.show()
 
-
-class NewOrbits:
-    """
-    Inputs:
-    dispersion (object of type dispersion)
-    interpolatedcurves (onject of type interpolatedcurves)
-    B (magnetic field as a 3-vector)
-    """
-    def __init__(self,dispersion,interpolatedcurves):
-        self.dispersion = dispersion
-        self.interpolatedcurves = interpolatedcurves
-
-        self.timespentfindingpoints = 0
-        self.orbitsEQS = self.interpolatedcurves.initialcurvesList

--- a/orbitcreation.py
+++ b/orbitcreation.py
@@ -7,7 +7,6 @@ import matplotlib.pyplot as plt
 from time import time
 import dispersion
 from numba import njit,cfunc
-from numbalsoda import lsoda_sig, lsoda
 
 ########################
 # Module to find number of CPUSnumbalsoda
@@ -38,10 +37,10 @@ class InterpolatedCurves:
     This class replaces the older InitialPoints class, and is compatible with the Conductivity class out of the box
     """
 
-    def __init__(self,n_points,n_cuts,dispersion,doublefermisurface):
+    def __init__(self,res_z,res_xy,dispersion,doublefermisurface):
         self.dispersion = dispersion
-        self.n_cuts = n_cuts
-        self.n_points = n_points
+        self.n_cuts = res_xy
+        self.n_points = res_z
 
         if not isinstance(doublefermisurface,bool): #check if doublefermisurface is correctly specified
             raise Exception("Argument doublefermisurface is not a boolean")
@@ -49,10 +48,10 @@ class InterpolatedCurves:
         self.doublefermisurface = doublefermisurface
         self.c = self.dispersion.c/(1+int(self.doublefermisurface)) #this makes c = dispersion.c/2 if doublefermisurface is True
 
-        self.planeZcoords = np.linspace(-(np.pi)/self.c,(np.pi)/self.c,n_points+1) #create zcoordinates, each defining a plane on which points used for interpolation will be found. Exclude endpoint so that zone can be multiplied easily
+        self.planeZcoords = np.linspace(-(np.pi)/self.c,(np.pi)/self.c,self.n_points+1) #create zcoordinates, each defining a plane on which points used for interpolation will be found. Exclude endpoint so that zone can be multiplied easily
         self.dkz = np.array([0,0,self.planeZcoords[1] - self.planeZcoords[0]]) #vector connecting two planes used for area calculations in conductivity
 
-        self.initialcurvesList = np.zeros((n_points,n_cuts,3)) #list of list of initialpoints lying on the fermi surface. each sublist should be a contiguous set of points. eg: [[point1-,point2-,point3-],[point1+,point2+,point3+]]
+        self.initialcurvesList = np.zeros((self.n_points,self.n_cuts,3)) #list of list of initialpoints lying on the fermi surface. each sublist should be a contiguous set of points. eg: [[point1-,point2-,point3-],[point1+,point2+,point3+]]
 
     def solveforpoints(self,parallelised=False):
         """


### PR DESCRIPTION
Vector decomp allows the use of a consistent fermi surface mesh as opposed to creating new orbits for every field angle. Angular variations in the magnetic field enter the calculation as derivative terms connecting different points on the fermi surface in two perpendicular directions. 